### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,0 +1,24 @@
+# This workflow is activated when Dependabot creates a pull request (PR).
+# However, GitHub's security model restricts workflows triggered by Dependabot
+# from accessing any secrets. Furthermore, the GITHUB_TOKEN can only be used
+# in read-only mode. To work around this, we need to split the workflow into
+# two parts, see:
+# https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544.
+# This workflow will trigger our main workflow via a `workflow_run` event. This
+# approach will grant our main workflow access to repository secrets as described in
+# the GitHub docs:
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
+#   The workflow started by the workflow_run event is able to access secrets and write tokens,
+#   even if the previous workflow was not. This is useful in cases where the previous workflow
+#   is intentionally not privileged, but you need to take a privileged action in a later workflow.
+
+name: Dependabot PR
+on:
+  pull_request
+
+jobs:
+  check-dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - run: echo "PR created by Dependabot"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,8 +20,21 @@ env:
 # https://github.com/semantic-release/semantic-release/blob/4bddb37de2fc6743a82299e277d5852d153e2ba8/lib/git.js#L67
 on:
   push:
+  workflow_run:
+    workflows: [ "Dependabot PR" ]
+    types:
+      - completed
 
 jobs:
+  # This job only runs if this workflow is triggered by Dependabot, in that case we make
+  # sure the triggering workflow 'Dependabot PR' completed successfully. That should
+  # always be the case, if not, something is seriously wrong.
+  check-result-dependabot-pr:
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'workflow_run') && (github.event.workflow_run.conclusion == 'failure') }}
+    steps:
+      - run: echo "The 'Dependabot PR' workflow failed, this should never happen" && exit 1
+
   format:
     runs-on: ubuntu-latest
     steps:
@@ -250,7 +263,8 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          # Skip pushing images for workflows triggered by Dependabot.
+          push: ${{ github.event_name != 'workflow_run' }}
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -305,7 +319,8 @@ jobs:
           context: ./clients/${{ matrix.target }}
           platforms: linux/amd64,linux/arm64
           build-args: VERSION=${{ needs.version.outputs.version }}${{ fromJSON(format('["-{0}",""]', github.ref_name))[github.ref_name == github.event.repository.default_branch] }}
-          push: true
+          # Skip pushing images for workflows triggered by Dependabot.
+          push: ${{ github.event_name != 'workflow_run' }}
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
We need to make sure we keep our dependencies up-to-date, including:
* Go modules
* Github Actions
* Docker base images 

GitHub's security model restricts workflows triggered by `Dependabot` from accessing any secrets. Furthermore, the `GITHUB_TOKEN` can only be used in read-only mode. To work around this, we need to split the workflow in two: the `Dependabot PR` workflow will be triggered by `Dependabot`, it will trigger our main workflow via a `workflow_run` event. This approach will grant our main workflow access to repository secrets as described in the [GitHub docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run): 
> The workflow started by the workflow_run event is able to access secrets and write tokens, even if the previous workflow was not. This is useful in cases where the previous workflow is intentionally not privileged, but you need to take a privileged action in a later workflow.

See: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544