### PR TITLE
Update module path to match major release

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/founda/aws-rds-authenticator/pkg/authtoken"
+	"github.com/founda/aws-rds-authenticator/v2/pkg/authtoken"
 )
 
 type option func(*authenticator) error

--- a/authenticator_test.go
+++ b/authenticator_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	authenticator "github.com/founda/aws-rds-authenticator"
-	"github.com/founda/aws-rds-authenticator/pkg/authtoken/mock"
+	authenticator "github.com/founda/aws-rds-authenticator/v2"
+	"github.com/founda/aws-rds-authenticator/v2/pkg/authtoken/mock"
 )
 
 func TestPrintsConnectionStringToWriter(t *testing.T) {

--- a/cmd/aws-rds-authenticator/main.go
+++ b/cmd/aws-rds-authenticator/main.go
@@ -1,6 +1,6 @@
 package main
 
-import authenticator "github.com/founda/aws-rds-authenticator"
+import authenticator "github.com/founda/aws-rds-authenticator/v2"
 
 func main() {
 	authenticator.PrintConnectionString()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/founda/aws-rds-authenticator
+module github.com/founda/aws-rds-authenticator/v2
 
 go 1.20
 


### PR DESCRIPTION
I tried to install it using `go install ...` but that fails as I never updated the module path to match the new v2.