### PR TITLE
feat: add the ability to skip token generation

### DIFF
--- a/authenticator_test.go
+++ b/authenticator_test.go
@@ -116,11 +116,6 @@ func TestMissingRequiredArgs(t *testing.T) {
 			want: "missing required user",
 		},
 		{
-			name: "missing region",
-			args: []string{"-host", "host", "-user", "user", "-database", "db"},
-			want: "missing required region",
-		},
-		{
 			name: "incorrect engine",
 			args: []string{"-host", "host", "-user", "user", "-region", "eu-west-1", "-database", "db", "-engine", "oracle"},
 			want: "invalid engine: must be postgres or mysql",

--- a/pkg/authtoken/local.go
+++ b/pkg/authtoken/local.go
@@ -1,0 +1,19 @@
+package authtoken
+
+import (
+	"context"
+)
+
+type TokenBuilder struct {
+	password string
+}
+
+func NewTokenBuilder(passwd string) *TokenBuilder {
+	return &TokenBuilder{
+		password: passwd,
+	}
+}
+
+func (b *TokenBuilder) BuildToken(ctx context.Context, endpoint, region, dbUser string) (string, error) {
+	return b.password, nil
+}


### PR DESCRIPTION
When this tool is baked into an image, it is hard to use this locally. We fix this by adding a "local" mode, simply enabled by setting PG_PASSWORD.