### PR TITLE
chore(deps): update base images

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           cache-dependency-path: go.sum
 
       - name: Verify formatting
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           cache-dependency-path: go.sum
 
       - name: Run Go Vet
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           cache-dependency-path: go.sum
 
       - name: Check imports
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           cache-dependency-path: go.sum
 
       - name: Verify go.mod is tidy
@@ -130,7 +130,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           cache-dependency-path: go.sum
 
       - name: Run Staticcheck
@@ -218,7 +218,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           cache-dependency-path: go.sum
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.20-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /workspace
 
@@ -34,7 +34,7 @@ USER app
 ENTRYPOINT [ "./aws-rds-authenticator" ]
 
 # alpine image
-FROM alpine:3.17 AS alpine
+FROM alpine:3.21 AS alpine
 
 RUN addgroup --system app --gid 888 && \
     adduser --system --no-create-home --uid 888 --ingroup app app

--- a/clients/mysql/Dockerfile
+++ b/clients/mysql/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=latest
 FROM ghcr.io/founda/aws-rds-authenticator:$VERSION-alpine AS aws-rds-authenticator
 
-FROM alpine:3.17
+FROM alpine:3.21
 RUN apk --no-cache add mysql-client
 
 WORKDIR /workspace

--- a/clients/postgres/Dockerfile
+++ b/clients/postgres/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=latest
 FROM ghcr.io/founda/aws-rds-authenticator:$VERSION-alpine AS aws-rds-authenticator
 
-FROM alpine:3.17
+FROM alpine:3.21
 RUN apk --no-cache add postgresql-client
 
 WORKDIR /workspace


### PR DESCRIPTION
This updates the Go build image to 1.24 (from 1.20, unsupported since 2024-02-06) and the Alpine image to 3.21 (from 3.17, unsupported since 2024-11-22).